### PR TITLE
fix the scroll bug movement and space

### DIFF
--- a/src/js/components/scroll-indicator.js
+++ b/src/js/components/scroll-indicator.js
@@ -7,14 +7,15 @@ const scrollIndicator = (data) => {
   image.alt = data.image.alt;
   const text = newText('p', data.text, ['scroll__text']);
   const section = newContainer('section', [button, text], ['scroll']);
-  button.addEventListener('click', () => {
+  const scrollFunction = () => {
     const scrollAnimation = document.getElementById(data.scrollTo);
-    const positions = scrollAnimation.getBoundingClientRect();
+    const position = scrollAnimation.offsetTop;
     window.scrollTo({
-      top: positions.top,
+      top: position,
       behavior: 'smooth',
     });
-  });
+  };
+  button.addEventListener('click', scrollFunction);
   return section;
 };
 

--- a/src/scss/components/_scroll-indicator.scss
+++ b/src/scss/components/_scroll-indicator.scss
@@ -1,6 +1,7 @@
 .scroll {
   background-color: $white;
   display: block;
+  margin-bottom:76px;
   padding: 20px;
 
   &__button {
@@ -14,7 +15,7 @@
 
   &__button:focus {
     outline: none;
-    }
+  }
 
   &__text {
     display: none;

--- a/src/scss/components/_scroll-indicator.scss
+++ b/src/scss/components/_scroll-indicator.scss
@@ -2,7 +2,7 @@
   background-color: $white;
   display: block;
   margin-bottom:76px;
-  padding: 20px;
+  padding: 20px 0 0 0;
 
   &__button {
     align-self: center;


### PR DESCRIPTION

fix  the bug reported by QA: 
the space between the scroll arrow and the next component is now like the original design.
the arrow scroll doesn't do the strange move that did before, fix the movement, so the scroll always hides the arrow.

Trello link : https://trello.com/c/xkCVKGtq/55-mobile-indicador-de-scroll-3